### PR TITLE
fix: Fix checkbox props in Form.Group

### DIFF
--- a/src/components/Form/Group.jsx
+++ b/src/components/Form/Group.jsx
@@ -68,6 +68,7 @@ export default class Group extends React.Component {
         }
       }
     });
+    this.props.hanldeCheck(check)
   };
 
   handleTitleClick = () => {

--- a/src/components/Slider/Slider.jsx
+++ b/src/components/Slider/Slider.jsx
@@ -237,7 +237,7 @@ export default class Slider extends React.Component {
     const { value } = e.target;
     this.setState(
       {
-        value: [min, Number(value)],
+        value: [min, value],
         left: 0,
         right: this.getValuePercent(Number(value)) * 100,
       },


### PR DESCRIPTION
1.子组件Form.Group通过回调把checkbox的check状态传递给父组件，让父组件可以根据check状态决定Form.Group内的children表单的validator rule is required or not。
2.Slider组件的Input，键盘Back键无法清空输入框，只能是0，建议修改