### PR TITLE
fix: Fix the setState of Select

### DIFF
--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -92,11 +92,19 @@ export default class Select extends React.Component {
     }
 
     if (!isUndefined(value) && value !== prevState.value) {
-      this.setState({
-        value,
-        inputValue: value,
-        inputVisible: false,
-      });
+      if (isEmpty(value)) {
+        this.setState({
+          value,
+          inputValue: value,
+          inputVisible: true,
+        });
+      } else {
+        this.setState({
+          value,
+          inputValue: value,
+          inputVisible: false,
+        });
+      }
     }
 
     if (this.state.visible && !prevState.visible) {


### PR DESCRIPTION
Signed-off-by: lannyfu <lannyfu@yunify.com>

When the state changes, the 'ComponentDidUpdate' lifecycle is called. If the 'InputVisible' is false, the 'PlaceHolder' will not be displayed. If the ‘value’ is empty, change the 'InputVisible' to true

To Fix # [#kubesphere/kubesphere/3543](https://github.com/kubesphere/kubesphere/issues/3543)

![034BDCD6-EA5A-40F0-9473-2C7643AD5934](https://user-images.githubusercontent.com/63338728/123908481-29917b80-d9aa-11eb-9873-b2827e446337.png)
