### PR TITLE
fix isActive on Select

### DIFF
--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -451,7 +451,7 @@ export default class Select extends React.Component {
     const { value } = this.state;
     const { multi, optionRenderer } = this.props;
     const isActive = (v) =>
-      multi ? value.includes(v.value) : v.value === value;
+      multi ? value.includes(v.value) : v.disabled ? false : v.value === value;
 
     return options.map((item, i) => {
       if (item.options) {


### PR DESCRIPTION
Signed-off-by: lannyfu <lannyfu@yunify.com>

To fix #[#kubesphere/console/2105](https://github.com/kubesphere/console/issues/2105)

![71627029874_ pic](https://user-images.githubusercontent.com/63338728/126762588-4c1904f4-ceae-41ff-aa6f-65f70ec68ccc.jpg)

When the input value is equal to the value of option and then the isActive of this option will change to true, but when the project is disabled, the `isActive` of it should not change to true