### PR TITLE
fix: Fix 'ks.cloud' project running errors due to misspelled words

### DIFF
--- a/src/components/Loading/styles.scss
+++ b/src/components/Loading/styles.scss
@@ -1,7 +1,7 @@
 @import "../../styles/variables";
 
 @keyframes loading {
-  form {
+  from {
     transform: rotate(0deg);
   }
 
@@ -51,7 +51,7 @@
       background: #fff;
       opacity: 0.3;
       transition: all 0.3s;
-      content: '';
+      content: "";
       z-index: 4;
     }
   }


### PR DESCRIPTION
Signed-off-by: lannyfu <lannyfu@yunify.com>

Installing @kube-design/components above 1.1.13 in ks.cloud will cause an error due to misspelling.