### PR TITLE
[codex] fix(tabs): return void in outline effect

### DIFF
--- a/packages/components/src/Tabs/Tabs.tsx
+++ b/packages/components/src/Tabs/Tabs.tsx
@@ -138,7 +138,7 @@ export function Tabs({
   const wrapperRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (variant === 'outline') return null;
+    if (variant === 'outline') return;
     const observer = new ResizeObserver(() => {
       if (_activeKey in refs.current && wrapperRef.current) {
         const element = refs.current[_activeKey];


### PR DESCRIPTION
## Title

fix: prevent page crash on `/apps/:appName` caused by `useEffect` returning `null`

## Background

The page crashes when visiting routes such as:

`/apps/:appName`

The console shows errors such as:

* `destroy is not a function`
* `useEffect must not return anything besides a function, which is used for clean-up. You returned null.`

<img width="1411" height="652" alt="image" src="https://github.com/user-attachments/assets/0488d795-950c-4160-a94a-d9ff4ab4f509" />


This triggers React Router's default error boundary and prevents the page from rendering properly.

## Root Cause

The return value of `useEffect` must be either:

* a cleanup function, or
* `undefined`

In the current implementation, `return null` is used inside `useEffect`.
This is not a valid return value for an effect and may cause React to fail during effect cleanup/unmount, resulting in a page crash.

## Fix

Replace `return null` in `useEffect` with `return`, so the effect returns `undefined` when no cleanup is needed.

### Before

```ts
useEffect(() => {
  ...
  return null
}, [])
```

### After

```ts
useEffect(() => {
  ...
  return
}, [])
```

## Impact

This change fixes the invalid `useEffect` return value affecting `/apps/:appName` routes and does not alter business logic.

## Validation

Verified the following on `/apps/:appName` routes:

* the page loads normally
* the page no longer crashes
* the console no longer shows `destroy is not a function`
* the console no longer shows the `useEffect must not return anything besides a function` warning
* related page behavior remains normal

## Risk

Low risk.

This is a narrow fix for React effect return behavior and does not change the original logic flow.

## Note

It may be worth checking for similar `return null` usage in other `useEffect` hooks to prevent the same issue elsewhere.
